### PR TITLE
Fix error to auto generate missing output folder

### DIFF
--- a/colorblindness.py
+++ b/colorblindness.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*- 
 
 import sys
+import os
 import math
 
 from draw_target import *
@@ -174,7 +175,11 @@ def main():
 
     image2.show()
     # show the generated test image(result)
-    image2.save('./sample_output/new_colorblindness_sample.png')
+
+    output_dir = "./sample_output"
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    image2.save(os.path.join(output_dir, 'new_colorblindness_sample.png'))
     # save the generated test image(result)
 
 


### PR DESCRIPTION
Issue #11 의 2번째에 제시된 버그를 해결합니다.
(1번째 항목의 경우 메인테이너분들이 결정하실 사항이라 판단해 넘어갔습니다.)

output 폴더가 없다면 자동으로 생성하는 방식으로 버그를 해결했습니다.